### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "reis"
 version = "0.2.0"
 license = "MIT"
 description = "Pure Rust implementation of libei/libeis protocol."
-homepage = "https://github.com/ids1024/reis"
+repository = "https://github.com/ids1024/reis"
 keywords = ["libei", "libeis", "wayland"]
 edition = "2021"
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.