### PR TITLE
Update `libei` bindings with touch cancel event/request

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,7 +24,7 @@ jobs:
       if: matrix.rust_version != 'stable'
     - run: cargo build --all-features --examples
       if: matrix.rust_version == 'stable'
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: reis-demo-server
         path: target/debug/examples/reis-demo-server
@@ -33,7 +33,7 @@ jobs:
     needs: check-and-build
     steps:
     - run: git clone https://gitlab.freedesktop.org/libinput/libei .
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: reis-demo-server
     - run: chmod +x reis-demo-server

--- a/examples/reis-demo-server.rs
+++ b/examples/reis-demo-server.rs
@@ -108,6 +108,9 @@ impl ContextState {
 
                 // TODO create devices; compare against current bitflag
             }
+            EisRequest::TouchCancel(request) => {
+                // TODO protocol error if version wrong
+            }
             _ => {}
         }
 

--- a/src/ei.rs
+++ b/src/ei.rs
@@ -4,7 +4,7 @@ use std::{
         io::{AsFd, AsRawFd, BorrowedFd, RawFd},
         net::UnixStream,
     },
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 
 use crate::{wire::Backend, PendingRequestResult};

--- a/src/eiproto_ei.rs
+++ b/src/eiproto_ei.rs
@@ -2591,12 +2591,33 @@ pub mod keyboard {
         /**
         Notification that the EIS implementation has changed group or modifier
         states on this device, but not necessarily in response to an
-        `ei_keyboard.key` event. Future `ei_keyboard.key` requests must take the
-        new group or modifier state into account.
+        `ei_keyboard.key` event or request. Future `ei_keyboard.key` requests must
+        take the new group and modifier state into account.
 
-        This event should not be sent in response to `ei_keyboard.key` events
-        that change the group or modifier state according to the keymap. The
-        client is expected to track such group or modifier states on its own.
+        This event should be sent any time the modifier state or effective group
+        has changed, whether caused by an `ei_keyboard.key` event in accordance
+        with the keymap, indirectly due to further handling of an
+        `ei_keyboard.key` event (e.g., because it triggered a keyboard shortcut
+        that then changed the state), or caused by an unrelated an event (e.g.,
+        input from a different keyboard, or a group change triggered by a layout
+        selection widget).
+
+        For receiver clients, modifiers events will always be properly ordered
+        with received key events, so each key event should be interpreted using
+        the most recently-received modifier state. The server should send this
+        event immediately following the `ei_device.frame` event for the key press
+        that caused the change. If the state change impacts multiple keyboards,
+        this event should be sent for all of them.
+
+        For sender clients, the modifiers event is not inherently synchronized
+        with key requests, but the client may send an `ei_connection.sync` request
+        when synchronization is required. When the corresponding
+        `ei_callback.done` event is received, all key requests sent prior to the
+        sync request are guaranteed to have been processed, and any
+        directly-resulting modifiers events are guaranteed to have been
+        received. Note, however, that it is still possible for
+        indirectly-triggered state changes, such as via a keyboard shortcut not
+        encoded in the keymap, to be reported after the done event.
 
         A client must assume that all modifiers are lifted when it
         receives an `ei_device.paused` event. The EIS implementation
@@ -2607,6 +2628,12 @@ pub mod keyboard {
         be processed immediately by the client.
 
         This event is only sent for devices with an `ei_keyboard.keymap.`
+
+        Note: A previous version of the documentation instead specified that
+        this event should not be sent in response to `ei_keyboard.key` events
+        that change the group or modifier state according to the keymap.
+        However, this complicated client implementation and resulted in
+        situations where the client state could get out of sync with the server.
          */
         Modifiers {
             /** this event's serial number */
@@ -2779,9 +2806,9 @@ pub mod touchscreen {
 
     impl Touchscreen {
         /**
-        Notification that the client is no longer interested in this touch.
+        Notification that the client is no longer interested in this touchscreen.
         The EIS implementation will release any resources related to this touch and
-        send the `ei_touch.destroyed` event once complete.
+        send the `ei_touchscreen.destroyed` event once complete.
          */
         pub fn release(&self) -> () {
             let args = &[];
@@ -2842,6 +2869,10 @@ pub mod touchscreen {
         up. The touchid is the unique id for this touch previously
         sent with `ei_touchscreen.down.`
 
+        If a touch is cancelled via `ei_touchscreen.cancel`, the `ei_touchscreen.up`
+        request must not be sent for this same touch. Likewise, a touch released
+        with `ei_touchscreen.up` must not be cancelled.
+
         The touchid may be re-used after this request.
 
         It is a protocol violation to send a touch up in the same
@@ -2851,6 +2882,32 @@ pub mod touchscreen {
             let args = &[wire::Arg::Uint32(touchid.into())];
 
             self.0.request(3, args);
+
+            ()
+        }
+
+        /**
+        Notifies the EIS implementation about an existing touch being cancelled.
+        This typically means that any effects the touch may have had on the
+        user interface should be reverted or otherwise made inconsequential.
+
+        This request replaces `ei_touchscreen.up` for the same touch.
+        If a touch is cancelled via `ei_touchscreen.cancel`, the `ei_touchscreen.up`
+        request must not be sent for this same touch. Likewise, a touch released
+        with `ei_touchscreen.up` must not be cancelled.
+
+        The touchid is the unique id for this touch previously
+        sent with `ei_touchscreen.down.`
+
+        The touchid may be re-used after this request.
+
+        It is a protocol violation to send a touch cancel
+        in the same frame as a touch motion or touch down.
+         */
+        pub fn cancel(&self, touchid: u32) -> () {
+            let args = &[wire::Arg::Uint32(touchid.into())];
+
+            self.0.request(4, args);
 
             ()
         }
@@ -2911,10 +2968,31 @@ pub mod touchscreen {
         It is a protocol violation to send this request for a client
         of an `ei_handshake.context_type` other than receiver.
 
+        If a touch is released via `ei_touchscreen.up`, no `ei_touchscreen.cancel`
+        event is sent for this same touch. Likewise, a touch released
+        with `ei_touchscreen.cancel` must not be released via `ei_touchscreen.up.`
+
         It is a protocol violation to send a touch up in the same
         frame as a touch motion or touch down.
          */
         Up {
+            /**  */
+            touchid: u32,
+        },
+        /**
+        See the `ei_touchscreen.cancel` request for details.
+
+        It is a protocol violation to send this event for a client
+        of an `ei_handshake.context_type` other than receiver.
+
+        If a touch is cancelled via `ei_touchscreen.cancel`, no `ei_touchscreen.up`
+        event is sent for this same touch. Likewise, a touch released
+        with `ei_touchscreen.up` must not be cancelled via `ei_touchscreen.cancel.`
+
+        It is a protocol violation to send a touch cancel event in the same
+        frame as a touch motion or touch down.
+         */
+        Cancel {
             /**  */
             touchid: u32,
         },
@@ -2927,6 +3005,7 @@ pub mod touchscreen {
                 1 => Some("down"),
                 2 => Some("motion"),
                 3 => Some("up"),
+                4 => Some("cancel"),
                 _ => None,
             }
         }
@@ -2960,6 +3039,11 @@ pub mod touchscreen {
 
                     Ok(Self::Up { touchid })
                 }
+                4 => {
+                    let touchid = _bytes.read_arg()?;
+
+                    Ok(Self::Cancel { touchid })
+                }
                 opcode => Err(wire::ParseError::InvalidOpcode("touchscreen", opcode)),
             }
         }
@@ -2989,6 +3073,9 @@ pub mod touchscreen {
                     args.push(y.as_arg());
                 }
                 Self::Up { touchid } => {
+                    args.push(touchid.as_arg());
+                }
+                Self::Cancel { touchid } => {
                     args.push(touchid.as_arg());
                 }
                 _ => unreachable!(),

--- a/src/event.rs
+++ b/src/event.rs
@@ -567,6 +567,13 @@ impl EiEventConverter {
                             touch_id: touchid,
                         }));
                     }
+                    ei::touchscreen::Event::Cancel { touchid } => {
+                        self.queue_event(EiEvent::TouchCancel(TouchCancel {
+                            device: device.clone(),
+                            time: 0,
+                            touch_id: touchid,
+                        }));
+                    }
                     ei::touchscreen::Event::Destroyed { serial } => {
                         self.connection.update_serial(serial);
                         // TODO does interface need to be removed from `Device`?
@@ -792,6 +799,7 @@ pub enum EiEvent {
     TouchDown(TouchDown),
     TouchUp(TouchUp),
     TouchMotion(TouchMotion),
+    TouchCancel(TouchCancel),
 }
 
 impl EiEvent {
@@ -810,6 +818,7 @@ impl EiEvent {
             Self::TouchDown(evt) => Some(&mut evt.time),
             Self::TouchUp(evt) => Some(&mut evt.time),
             Self::TouchMotion(evt) => Some(&mut evt.time),
+            Self::TouchCancel(evt) => Some(&mut evt.time),
             _ => None,
         }
     }
@@ -973,6 +982,13 @@ pub struct TouchUp {
     pub touch_id: u32,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+pub struct TouchCancel {
+    pub device: Device,
+    pub time: u64,
+    pub touch_id: u32,
+}
+
 pub trait SeatEvent {
     fn seat(&self) -> &Seat;
 }
@@ -1043,6 +1059,7 @@ impl_device_trait!(KeyboardKey; time);
 impl_device_trait!(TouchDown; time);
 impl_device_trait!(TouchUp; time);
 impl_device_trait!(TouchMotion; time);
+impl_device_trait!(TouchCancel; time);
 
 pub struct EiConvertEventIterator {
     context: ei::Context,

--- a/src/request.rs
+++ b/src/request.rs
@@ -389,6 +389,13 @@ impl EisRequestConverter {
                             time: 0,
                         }));
                     }
+                    eis::touchscreen::Request::Cancel { touchid } => {
+                        self.queue_request(EisRequest::TouchCancel(TouchCancel {
+                            device,
+                            touch_id: touchid,
+                            time: 0,
+                        }));
+                    }
                 }
             }
         }
@@ -677,6 +684,7 @@ pub enum EisRequest {
     TouchDown(TouchDown),
     TouchUp(TouchUp),
     TouchMotion(TouchMotion),
+    TouchCancel(TouchCancel),
 }
 
 impl EisRequest {
@@ -695,6 +703,7 @@ impl EisRequest {
             Self::TouchDown(evt) => Some(&mut evt.time),
             Self::TouchUp(evt) => Some(&mut evt.time),
             Self::TouchMotion(evt) => Some(&mut evt.time),
+            Self::TouchCancel(evt) => Some(&mut evt.time),
             _ => None,
         }
     }
@@ -810,6 +819,13 @@ pub struct TouchMotion {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct TouchUp {
+    pub device: Device,
+    pub time: u64,
+    pub touch_id: u32,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct TouchCancel {
     pub device: Device,
     pub time: u64,
     pub touch_id: u32,

--- a/src/request.rs
+++ b/src/request.rs
@@ -390,6 +390,12 @@ impl EisRequestConverter {
                         }));
                     }
                     eis::touchscreen::Request::Cancel { touchid } => {
+                        if touchscreen.version() < 2 {
+                            return Err(Error::InvalidInterfaceVersion(
+                                "ei_touchscreen",
+                                touchscreen.version(),
+                            ));
+                        }
                         self.queue_request(EisRequest::TouchCancel(TouchCancel {
                             device,
                             touch_id: touchid,


### PR DESCRIPTION
This is still waiting for a release of libei.