### PR TITLE
Add enumflags2 for DeviceCapability enum

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,11 +19,24 @@ jobs:
     - run: sudo apt-get -qq update
     - run: sudo apt-get install -y libxkbcommon-dev
     - run: cargo fmt --all -- --check
+
+    # Make sure there are no broken intra-doc links with and without features
+    - run: RUSTDOCFLAGS="--deny warnings" cargo doc --no-deps --all-features
+    - run: RUSTDOCFLAGS="--deny warnings" cargo doc --no-deps
+
     - run: cargo clippy --all-features -- -Dwarnings
+      if: matrix.rust_version != 'stable'
+    - run: cargo clippy --all-features --all-targets -- -Dwarnings
+      if: matrix.rust_version == 'stable'
+
+    # Sanity check: generic code doesn't depend on features
+    - run: cargo check
+
     - run: cargo build --all-features
       if: matrix.rust_version != 'stable'
     - run: cargo build --all-features --examples
       if: matrix.rust_version == 'stable'
+
     - uses: actions/upload-artifact@v4
       with:
         name: reis-demo-server

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,17 @@ tokio = { version = "1.31.0", features = ["rt", "macros"] }
 signal-hook = "0.3.17"
 pollster = "0.4.0"
 
+[lints.clippy]
+pedantic = "warn"
+# Blocked by MSRV
+#allow_attributes = "warn"
+#allow_attributes_without_reason = "warn"
+#should_panic_without_expect = "warn"
+str_to_string = "warn"
+string_to_string = "warn"
+cast_possible_wrap = { level = "allow", priority = 1 }
+cast_possible_truncation = { level = "allow", priority = 1 }
+
 [features]
 tokio = ["dep:tokio", "futures"]
 # Experimental and somewhat incomplete

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ calloop = { version = "0.14.0", optional = true }
 rustix = { version = "0.38.3", features = ["event", "fs", "net", "time"] }
 futures = { version = "0.3.28", optional = true }
 tokio = { version = "1.31.0", features = ["net"], optional = true }
+enumflags2 = "0.7.12"
 
 [dev-dependencies]
 ashpd = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ tokio = { version = "1.31.0", features = ["rt", "macros"] }
 signal-hook = "0.3.17"
 pollster = "0.4.0"
 
+[lints.rust]
+missing_docs = "warn"
+
 [lints.clippy]
 pedantic = "warn"
 # Blocked by MSRV

--- a/examples/list-devices.rs
+++ b/examples/list-devices.rs
@@ -104,13 +104,12 @@ impl State {
                     _ => {}
                 }
             }
-            ei::Event::Callback(callback, request) => match request {
-                ei::callback::Event::Done { callback_data: _ } => {
+            ei::Event::Callback(callback, request) => {
+                if let ei::callback::Event::Done { callback_data: _ } = request {
                     // TODO: Callback being called after first device, but not later ones?
                     // self.print_and_exit_if_done();
                 }
-                _ => {}
-            },
+            }
             _ => {}
         }
 

--- a/examples/list-devices.rs
+++ b/examples/list-devices.rs
@@ -1,3 +1,5 @@
+//! List devices with sender context type.
+
 use ashpd::desktop::remote_desktop::{DeviceType, RemoteDesktop};
 use futures::stream::StreamExt;
 use reis::{ei, tokio::EiEventStream, PendingRequestResult};

--- a/examples/receive-synchronous.rs
+++ b/examples/receive-synchronous.rs
@@ -34,7 +34,7 @@ async fn open_connection() -> ei::Context {
                 let x = region.x_offset();
                 let y = region.y_offset();
                 let w = region.width() as i32;
-                let h = region.height() as i32;
+                let _h = region.height() as i32;
                 Barrier::new(NonZero::new(n as u32 + 1).unwrap(), (x, y, x + w - 1, y))
             })
             .collect::<Vec<_>>();
@@ -72,7 +72,7 @@ fn main() {
                         | DeviceCapability::Scroll
                         | DeviceCapability::Button,
                 );
-                context.flush();
+                let _ = context.flush();
             }
             reis::event::EiEvent::DeviceAdded(evt) => {
                 println!("  seat: {:?}", evt.device.seat().name());

--- a/examples/receive-synchronous.rs
+++ b/examples/receive-synchronous.rs
@@ -1,3 +1,5 @@
+//! Capturing input synchronously.
+
 use ashpd::desktop::input_capture::{Barrier, Capabilities, InputCapture};
 use pollster::FutureExt as _;
 use reis::{ei, event::DeviceCapability};

--- a/examples/receive-synchronous.rs
+++ b/examples/receive-synchronous.rs
@@ -78,11 +78,11 @@ fn main() {
                 println!("  seat: {:?}", evt.device.seat().name());
                 println!("  type: {:?}", evt.device.device_type());
                 if let Some(dimensions) = evt.device.dimensions() {
-                    println!("  dimensions: {:?}", dimensions);
+                    println!("  dimensions: {dimensions:?}");
                 }
                 println!("  regions: {:?}", evt.device.regions());
                 if let Some(keymap) = evt.device.keymap() {
-                    println!("  keymap: {:?}", keymap);
+                    println!("  keymap: {keymap:?}");
                 }
                 // Interfaces?
             }

--- a/examples/receive-synchronous.rs
+++ b/examples/receive-synchronous.rs
@@ -64,14 +64,14 @@ fn main() {
         match &event {
             reis::event::EiEvent::SeatAdded(evt) => {
                 // println!("    capabilities: {:?}", evt.seat);
-                evt.seat.bind_capabilities(&[
-                    DeviceCapability::Pointer,
-                    DeviceCapability::PointerAbsolute,
-                    DeviceCapability::Keyboard,
-                    DeviceCapability::Touch,
-                    DeviceCapability::Scroll,
-                    DeviceCapability::Button,
-                ]);
+                evt.seat.bind_capabilities(
+                    DeviceCapability::Pointer
+                        | DeviceCapability::PointerAbsolute
+                        | DeviceCapability::Keyboard
+                        | DeviceCapability::Touch
+                        | DeviceCapability::Scroll
+                        | DeviceCapability::Button,
+                );
                 context.flush();
             }
             reis::event::EiEvent::DeviceAdded(evt) => {

--- a/examples/receive.rs
+++ b/examples/receive.rs
@@ -79,11 +79,11 @@ async fn main() {
                 println!("  seat: {:?}", evt.device.seat().name());
                 println!("  type: {:?}", evt.device.device_type());
                 if let Some(dimensions) = evt.device.dimensions() {
-                    println!("  dimensions: {:?}", dimensions);
+                    println!("  dimensions: {dimensions:?}");
                 }
                 println!("  regions: {:?}", evt.device.regions());
                 if let Some(keymap) = evt.device.keymap() {
-                    println!("  keymap: {:?}", keymap);
+                    println!("  keymap: {keymap:?}");
                 }
                 // Interfaces?
             }

--- a/examples/receive.rs
+++ b/examples/receive.rs
@@ -36,7 +36,7 @@ async fn open_connection() -> ei::Context {
                 let x = region.x_offset();
                 let y = region.y_offset();
                 let w = region.width() as i32;
-                let h = region.height() as i32;
+                let _h = region.height() as i32;
                 Barrier::new(NonZero::new(n as u32 + 1).unwrap(), (x, y, x + w - 1, y))
             })
             .collect::<Vec<_>>();
@@ -75,7 +75,7 @@ async fn main() {
                         | DeviceCapability::Scroll
                         | DeviceCapability::Button,
                 );
-                context.flush();
+                let _ = context.flush();
             }
             reis::event::EiEvent::DeviceAdded(evt) => {
                 println!("  seat: {:?}", evt.device.seat().name());

--- a/examples/receive.rs
+++ b/examples/receive.rs
@@ -12,7 +12,7 @@ async fn open_connection() -> ei::Context {
         let session = input_capture
             .create_session(
                 None,
-                (Capabilities::Keyboard | Capabilities::Pointer | Capabilities::Touchscreen).into(),
+                Capabilities::Keyboard | Capabilities::Pointer | Capabilities::Touchscreen,
             )
             .await
             .unwrap()
@@ -65,14 +65,14 @@ async fn main() {
         match &event {
             reis::event::EiEvent::SeatAdded(evt) => {
                 // println!("    capabilities: {:?}", evt.seat);
-                evt.seat.bind_capabilities(&[
-                    DeviceCapability::Pointer,
-                    DeviceCapability::PointerAbsolute,
-                    DeviceCapability::Keyboard,
-                    DeviceCapability::Touch,
-                    DeviceCapability::Scroll,
-                    DeviceCapability::Button,
-                ]);
+                evt.seat.bind_capabilities(
+                    DeviceCapability::Pointer
+                        | DeviceCapability::PointerAbsolute
+                        | DeviceCapability::Keyboard
+                        | DeviceCapability::Touch
+                        | DeviceCapability::Scroll
+                        | DeviceCapability::Button,
+                );
                 context.flush();
             }
             reis::event::EiEvent::DeviceAdded(evt) => {

--- a/examples/receive.rs
+++ b/examples/receive.rs
@@ -1,3 +1,5 @@
+//! Capturing input asynchronously.
+
 use ashpd::desktop::input_capture::{Barrier, Capabilities, InputCapture};
 use futures::stream::StreamExt;
 use reis::{ei, event::DeviceCapability};

--- a/examples/reis-demo-server.rs
+++ b/examples/reis-demo-server.rs
@@ -1,3 +1,4 @@
+//! Demo server.
 // TODO: Require context_type
 
 use reis::{

--- a/examples/reis-demo-server.rs
+++ b/examples/reis-demo-server.rs
@@ -112,7 +112,7 @@ struct State {
 
 impl State {
     fn handle_new_connection(&mut self, context: eis::Context) -> io::Result<calloop::PostAction> {
-        println!("New connection: {:?}", context);
+        println!("New connection: {context:?}");
 
         let source = EisRequestSource::new(context, 1);
         let mut context_state = ContextState { seat: None };

--- a/examples/reis-demo-server.rs
+++ b/examples/reis-demo-server.rs
@@ -124,7 +124,19 @@ impl State {
                     connected_state,
                     event,
                 )),
-                Err(err) => Ok(context_state.protocol_error(connected_state, &err.to_string())),
+                Err(err) => {
+                    if let reis::Error::Request(reis::request::RequestError::InvalidCapabilities) =
+                        err
+                    {
+                        Ok(context_state.disconnected(
+                            connected_state,
+                            eis::connection::DisconnectReason::Value,
+                            &err.to_string(),
+                        ))
+                    } else {
+                        Ok(context_state.protocol_error(connected_state, &err.to_string()))
+                    }
+                }
             })
             .unwrap();
 

--- a/examples/reis-demo-server.rs
+++ b/examples/reis-demo-server.rs
@@ -50,58 +50,49 @@ impl ContextState {
             EisRequest::Bind(request) => {
                 let capabilities = request.capabilities;
 
-                // TODO Handle in converter
-                if capabilities & 0x7e != capabilities {
-                    return self.disconnected(
-                        connection,
-                        eis::connection::DisconnectReason::Value,
-                        "Invalid capabilities",
-                    );
-                }
-
                 let seat = self.seat.as_ref().unwrap();
 
                 if connection.has_interface("ei_keyboard")
-                    && capabilities & 2 << DeviceCapability::Keyboard as u64 != 0
+                    && capabilities.contains(DeviceCapability::Keyboard)
                 {
                     seat.add_device(
                         Some("keyboard"),
                         DeviceType::Virtual,
-                        &[DeviceCapability::Keyboard],
+                        DeviceCapability::Keyboard.into(),
                         |_| {},
                     );
                 }
 
                 // XXX button/etc should be on same object
                 if connection.has_interface("ei_pointer")
-                    && capabilities & 2 << DeviceCapability::Pointer as u64 != 0
+                    && capabilities.contains(DeviceCapability::Pointer)
                 {
                     seat.add_device(
                         Some("pointer"),
                         DeviceType::Virtual,
-                        &[DeviceCapability::Pointer],
+                        DeviceCapability::Pointer.into(),
                         |_| {},
                     );
                 }
 
                 if connection.has_interface("ei_touchscreen")
-                    && capabilities & 2 << DeviceCapability::Touch as u64 != 0
+                    && capabilities.contains(DeviceCapability::Touch)
                 {
                     seat.add_device(
                         Some("touch"),
                         DeviceType::Virtual,
-                        &[DeviceCapability::Touch],
+                        DeviceCapability::Touch.into(),
                         |_| {},
                     );
                 }
 
                 if connection.has_interface("ei_pointer_absolute")
-                    && capabilities & 2 << DeviceCapability::PointerAbsolute as u64 != 0
+                    && capabilities.contains(DeviceCapability::PointerAbsolute)
                 {
                     seat.add_device(
                         Some("pointer-abs"),
                         DeviceType::Virtual,
-                        &[DeviceCapability::PointerAbsolute],
+                        DeviceCapability::PointerAbsolute.into(),
                         |_| {},
                     );
                 }
@@ -148,16 +139,14 @@ impl State {
             connection.flush();
         }
 
-        let seat = connection.add_seat(
+        let _seat = connection.add_seat(
             Some("default"),
-            &[
-                DeviceCapability::Pointer,
-                DeviceCapability::PointerAbsolute,
-                DeviceCapability::Keyboard,
-                DeviceCapability::Touch,
-                DeviceCapability::Scroll,
-                DeviceCapability::Button,
-            ],
+            DeviceCapability::Pointer
+                | DeviceCapability::PointerAbsolute
+                | DeviceCapability::Keyboard
+                | DeviceCapability::Touch
+                | DeviceCapability::Scroll
+                | DeviceCapability::Button,
         );
     }
 
@@ -179,14 +168,12 @@ impl State {
 
                 let seat = connection.add_seat(
                     Some("default"),
-                    &[
-                        DeviceCapability::Pointer,
-                        DeviceCapability::PointerAbsolute,
-                        DeviceCapability::Keyboard,
-                        DeviceCapability::Touch,
-                        DeviceCapability::Scroll,
-                        DeviceCapability::Button,
-                    ],
+                    DeviceCapability::Pointer
+                        | DeviceCapability::PointerAbsolute
+                        | DeviceCapability::Keyboard
+                        | DeviceCapability::Touch
+                        | DeviceCapability::Scroll
+                        | DeviceCapability::Button,
                 );
 
                 context_state.seat = Some(seat);

--- a/examples/type-text.rs
+++ b/examples/type-text.rs
@@ -1,3 +1,5 @@
+//! Typing text.
+
 use ashpd::desktop::{
     remote_desktop::{DeviceType, RemoteDesktop},
     PersistMode,

--- a/examples/type-text.rs
+++ b/examples/type-text.rs
@@ -54,7 +54,7 @@ impl State {
         &mut self,
         context: &mut ei::Context,
     ) -> io::Result<calloop::PostAction> {
-        if let Err(_) = context.read() {
+        if context.read().is_err() {
             return Ok(calloop::PostAction::Remove);
         }
 
@@ -193,31 +193,29 @@ impl State {
                     }
                 }
                 ei::Event::Keyboard(keyboard, request) => {
-                    match request {
-                        ei::keyboard::Event::Keymap {
-                            keymap_type,
-                            size,
-                            keymap,
-                        } => {
-                            // XXX format
-                            // flags?
-                            // handle multiple keyboard?
-                            let context = xkb::Context::new(0);
-                            self.keymap = Some(
-                                unsafe {
-                                    xkb::Keymap::new_from_fd(
-                                        &context,
-                                        keymap,
-                                        size as _,
-                                        xkb::KEYMAP_FORMAT_TEXT_V1,
-                                        0,
-                                    )
-                                }
-                                .unwrap()
-                                .unwrap(),
-                            );
-                        }
-                        _ => {}
+                    if let ei::keyboard::Event::Keymap {
+                        keymap_type,
+                        size,
+                        keymap,
+                    } = request
+                    {
+                        // XXX format
+                        // flags?
+                        // handle multiple keyboard?
+                        let context = xkb::Context::new(0);
+                        self.keymap = Some(
+                            unsafe {
+                                xkb::Keymap::new_from_fd(
+                                    &context,
+                                    keymap,
+                                    size as _,
+                                    xkb::KEYMAP_FORMAT_TEXT_V1,
+                                    0,
+                                )
+                            }
+                            .unwrap()
+                            .unwrap(),
+                        );
                     }
                 }
                 _ => {}

--- a/src/calloop.rs
+++ b/src/calloop.rs
@@ -1,3 +1,5 @@
+//! Module containing [`calloop`] sources.
+
 // TODO Define an event source that reads socket and produces eis::Event
 // - is it easy to compose and wrap with handshaker, event handler?
 // produce an event of some kind on disconnect/eof?
@@ -11,12 +13,14 @@ use crate::{
     Error, PendingRequestResult,
 };
 
+/// [`calloop`] source that receives EI connections by listening on a socket.
 #[derive(Debug)]
 pub struct EisListenerSource {
     source: Generic<eis::Listener>,
 }
 
 impl EisListenerSource {
+    /// Creates a new EIS listener source.
     #[must_use]
     pub fn new(listener: eis::Listener) -> Self {
         Self {
@@ -160,6 +164,7 @@ enum State {
     Connected(ConnectedContextState),
 }
 
+/// [`calloop`] source that receives EI protocol requests.
 #[derive(Debug)]
 pub struct EisRequestSource {
     source: Generic<eis::Context>,
@@ -167,6 +172,7 @@ pub struct EisRequestSource {
 }
 
 impl EisRequestSource {
+    /// Creates a new EIS request source.
     #[must_use]
     pub fn new(context: eis::Context, initial_serial: u32) -> Self {
         let handshaker = crate::handshake::EisHandshaker::new(&context, initial_serial);
@@ -243,9 +249,13 @@ impl calloop::EventSource for EisRequestSource {
 }
 
 // TODO
+/// Event returned by [`EisRequestSource`].
 #[derive(Debug)]
 pub enum EisRequestSourceEvent {
+    /// Handshake has finished.
     Connected,
+    /// High-level request to EIS.
     Request(request::EisRequest),
+    /// Invalid object ID.
     InvalidObject(u64),
 }

--- a/src/calloop.rs
+++ b/src/calloop.rs
@@ -17,6 +17,7 @@ pub struct EisListenerSource {
 }
 
 impl EisListenerSource {
+    #[must_use]
     pub fn new(listener: eis::Listener) -> Self {
         Self {
             source: Generic::new(listener, Interest::READ, Mode::Level),
@@ -166,6 +167,7 @@ pub struct EisRequestSource {
 }
 
 impl EisRequestSource {
+    #[must_use]
     pub fn new(context: eis::Context, initial_serial: u32) -> Self {
         let handshaker = crate::handshake::EisHandshaker::new(&context, initial_serial);
         Self {

--- a/src/ei.rs
+++ b/src/ei.rs
@@ -98,6 +98,7 @@ impl Context {
     }
 
     /// Returns the interface proxy for the `ei_handshake` object.
+    #[must_use]
     pub fn handshake(&self) -> handshake::Handshake {
         self.0.object_for_id(0).unwrap().downcast_unchecked()
     }

--- a/src/ei.rs
+++ b/src/ei.rs
@@ -44,7 +44,7 @@ impl Context {
     /// use std::os::unix::net::UnixStream;
     /// use reis::ei::Context;
     ///
-    /// let socket = UnixStream::connect("/example/path");
+    /// let socket = UnixStream::connect("/example/path").unwrap();
     /// // Or receive from, for example, the RemoteDesktop XDG desktop protal.
     ///
     /// let context = Context::new(socket).unwrap();

--- a/src/eiproto.rs.jinja
+++ b/src/eiproto.rs.jinja
@@ -1,5 +1,23 @@
 {# ei-scanner jinja template, for `` #}
-#![allow(unknown_lints, unused_imports, unused_parens, clippy::useless_conversion, clippy::double_parens, clippy::match_single_binding, clippy::unused_unit, clippy::empty_docs, clippy::doc_lazy_continuation)]
+#![allow(
+    unknown_lints,
+    unused_imports,
+    unused_parens,
+    clippy::useless_conversion,
+    clippy::double_parens,
+    clippy::match_single_binding,
+    clippy::unused_unit,
+    clippy::empty_docs,
+    clippy::doc_lazy_continuation,
+
+    // Explicitly set to warn
+    clippy::doc_markdown,
+    clippy::must_use_candidate,
+    clippy::semicolon_if_nothing_returned,
+    clippy::used_underscore_binding,
+    clippy::match_same_arms,
+    clippy::str_to_string,
+)]
 
 // GENERATED FILE
 

--- a/src/eiproto.rs.jinja
+++ b/src/eiproto.rs.jinja
@@ -17,6 +17,7 @@
     clippy::used_underscore_binding,
     clippy::match_same_arms,
     clippy::str_to_string,
+    missing_docs,
 )]
 
 // GENERATED FILE

--- a/src/eiproto_ei.rs
+++ b/src/eiproto_ei.rs
@@ -7,7 +7,15 @@
     clippy::match_single_binding,
     clippy::unused_unit,
     clippy::empty_docs,
-    clippy::doc_lazy_continuation
+    clippy::doc_lazy_continuation,
+
+    // Explicitly set to warn
+    clippy::doc_markdown,
+    clippy::must_use_candidate,
+    clippy::semicolon_if_nothing_returned,
+    clippy::used_underscore_binding,
+    clippy::match_same_arms,
+    clippy::str_to_string,
 )]
 
 // GENERATED FILE

--- a/src/eiproto_ei.rs
+++ b/src/eiproto_ei.rs
@@ -16,6 +16,7 @@
     clippy::used_underscore_binding,
     clippy::match_same_arms,
     clippy::str_to_string,
+    missing_docs,
 )]
 
 // GENERATED FILE

--- a/src/eiproto_eis.rs
+++ b/src/eiproto_eis.rs
@@ -7,7 +7,15 @@
     clippy::match_single_binding,
     clippy::unused_unit,
     clippy::empty_docs,
-    clippy::doc_lazy_continuation
+    clippy::doc_lazy_continuation,
+
+    // Explicitly set to warn
+    clippy::doc_markdown,
+    clippy::must_use_candidate,
+    clippy::semicolon_if_nothing_returned,
+    clippy::used_underscore_binding,
+    clippy::match_same_arms,
+    clippy::str_to_string,
 )]
 
 // GENERATED FILE

--- a/src/eiproto_eis.rs
+++ b/src/eiproto_eis.rs
@@ -16,6 +16,7 @@
     clippy::used_underscore_binding,
     clippy::match_same_arms,
     clippy::str_to_string,
+    missing_docs,
 )]
 
 // GENERATED FILE

--- a/src/eis.rs
+++ b/src/eis.rs
@@ -134,6 +134,7 @@ impl Context {
     }
 
     /// Returns the interface proxy for the `ei_handshake` object.
+    #[must_use]
     pub fn handshake(&self) -> handshake::Handshake {
         self.0.object_for_id(0).unwrap().downcast_unchecked()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,7 +22,7 @@ impl fmt::Display for Error {
                 write!(f, "invalid version {version} for interface '{interface}'")
             }
             Self::Event(err) => write!(f, "event error: {err}"),
-            Self::Request(err) => write!(f, "request error: {}", err),
+            Self::Request(err) => write!(f, "request error: {err}"),
             Self::Io(err) => write!(f, "IO error: {err}"),
             Self::Handshake(err) => write!(f, "handshake error: {err}"),
             Self::Parse(err) => write!(f, "parse error: {err}"),

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,13 +4,20 @@ use std::{fmt, io};
 /// An error coming from the `reis` crate
 #[derive(Debug)]
 pub enum Error {
+    /// Handshake event after handshake.
     UnexpectedHandshakeEvent,
+    /// Invalid interface version
     InvalidInterfaceVersion(&'static str, u32),
     // TODO better error type here?
+    /// Protocol error caused by server.
     Event(EventError),
+    /// Protocol error caused by client.
     Request(RequestError),
+    /// Wire format parse error.
     Parse(ParseError),
+    /// Handshake error.
     Handshake(HandshakeError),
+    /// I/O error.
     Io(io::Error),
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-use crate::{event::EventError, handshake::HandshakeError, ParseError};
+use crate::{event::EventError, handshake::HandshakeError, request::RequestError, ParseError};
 use std::{fmt, io};
 
 /// An error coming from the `reis` crate
@@ -8,6 +8,7 @@ pub enum Error {
     InvalidInterfaceVersion(&'static str, u32),
     // TODO better error type here?
     Event(EventError),
+    Request(RequestError),
     Parse(ParseError),
     Handshake(HandshakeError),
     Io(io::Error),
@@ -21,6 +22,7 @@ impl fmt::Display for Error {
                 write!(f, "invalid version {version} for interface '{interface}'")
             }
             Self::Event(err) => write!(f, "event error: {err}"),
+            Self::Request(err) => write!(f, "request error: {}", err),
             Self::Io(err) => write!(f, "IO error: {err}"),
             Self::Handshake(err) => write!(f, "handshake error: {err}"),
             Self::Parse(err) => write!(f, "parse error: {err}"),
@@ -31,6 +33,12 @@ impl fmt::Display for Error {
 impl From<EventError> for Error {
     fn from(err: EventError) -> Self {
         Self::Event(err)
+    }
+}
+
+impl From<RequestError> for Error {
+    fn from(err: RequestError) -> Self {
+        Self::Request(err)
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -72,6 +72,7 @@ pub struct Connection(Arc<ConnectionInner>);
 
 impl Connection {
     /// Returns the interface proxy for the underlying `ei_connection` object.
+    #[must_use]
     pub fn connection(&self) -> &ei::Connection {
         &self.0.handshake_resp.connection
     }
@@ -88,6 +89,7 @@ impl Connection {
     // TODO(axka, 2025-07-08): specify in the function name that this is the last serial from
     // the server, and not the client, and create a function for the other way around.
     /// Returns the last serial number used in an event by the server.
+    #[must_use]
     pub fn serial(&self) -> u32 {
         self.0.serial.load(Ordering::Relaxed)
     }
@@ -108,6 +110,7 @@ pub struct EiEventConverter {
 }
 
 impl EiEventConverter {
+    #[must_use]
     pub fn new(context: &ei::Context, handshake_resp: HandshakeResp) -> Self {
         Self {
             pending_seats: HashMap::new(),
@@ -126,6 +129,7 @@ impl EiEventConverter {
         }
     }
 
+    #[must_use]
     pub fn connection(&self) -> &Connection {
         &self.connection
     }
@@ -755,6 +759,7 @@ impl std::hash::Hash for Seat {
 
 impl Seat {
     /// Returns the name of the seat, as provided by the server.
+    #[must_use]
     pub fn name(&self) -> Option<&str> {
         self.0.name.as_deref()
     }
@@ -805,36 +810,43 @@ impl fmt::Debug for Device {
 
 impl Device {
     /// Returns the high-level [`Seat`] wrapper for the device.
+    #[must_use]
     pub fn seat(&self) -> &Seat {
         &self.0.seat
     }
 
     /// Returns the interface proxy for the underlying `ei_device` object.
+    #[must_use]
     pub fn device(&self) -> &ei::Device {
         &self.0.device
     }
 
     /// Returns the name of the device, as provided by the server.
+    #[must_use]
     pub fn name(&self) -> Option<&str> {
         self.0.name.as_deref()
     }
 
     /// Returns the device's type.
+    #[must_use]
     pub fn device_type(&self) -> ei::device::DeviceType {
         self.0.device_type.unwrap()
     }
 
     /// Returns the device's dimensions, if applicable.
+    #[must_use]
     pub fn dimensions(&self) -> Option<(u32, u32)> {
         self.0.dimensions
     }
 
     /// Returns the device's regions.
+    #[must_use]
     pub fn regions(&self) -> &[Region] {
         &self.0.regions
     }
 
     /// Returns the device's keymap, if applicable.
+    #[must_use]
     pub fn keymap(&self) -> Option<&Keymap> {
         self.0.keymap.as_ref()
     }
@@ -842,11 +854,13 @@ impl Device {
     /// Returns an interface proxy if it is implemented for this device.
     ///
     /// Interfaces of devices are implemented, such that there is one `ei_device` object and other objects (for example `ei_keyboard`) denoting capabilities.
+    #[must_use]
     pub fn interface<T: ei::Interface>(&self) -> Option<T> {
         self.0.interfaces.get(T::NAME)?.clone().downcast()
     }
 
     /// Returns `true` if this device has an interface matching the provided capability.
+    #[must_use]
     pub fn has_capability(&self, capability: DeviceCapability) -> bool {
         self.0.interfaces.contains_key(capability.interface_name())
     }
@@ -1271,7 +1285,7 @@ impl Iterator for EiConvertEventIterator {
                 Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return None,
                 Err(err) => return Some(Err(err.into())),
                 Ok(_) => {}
-            };
+            }
             while let Some(result) = self.context.pending_event() {
                 let request = match result {
                     PendingRequestResult::Request(request) => request,

--- a/src/event.rs
+++ b/src/event.rs
@@ -29,14 +29,22 @@ use std::{
     },
 };
 
+/// Protocol errors of the server.
 #[derive(Debug)]
 pub enum EventError {
+    /// Non-setup device event before `done`.
     DeviceEventBeforeDone,
+    /// Device setup event after `done`.
     DeviceSetupEventAfterDone,
+    /// Seat setup event after `done`.
     SeatSetupEventAfterDone,
+    /// Non-setup seat event before `done`.
     SeatEventBeforeDone,
+    /// `ei_device.device_type` was not sent before `done`.
     NoDeviceType,
+    /// Handshake event after handshake.
     UnexpectedHandshakeEvent,
+    /// Non-negotiated interface advertised in `ei_device.capability`.
     UnknownCapabilityInterface,
 }
 
@@ -114,6 +122,7 @@ pub struct EiEventConverter {
 }
 
 impl EiEventConverter {
+    /// Creates a new converter.
     #[must_use]
     pub fn new(context: &ei::Context, handshake_resp: HandshakeResp) -> Self {
         Self {
@@ -133,6 +142,7 @@ impl EiEventConverter {
         }
     }
 
+    /// Returns a handle to the connection used by this converer.
     #[must_use]
     pub fn connection(&self) -> &Connection {
         &self.connection
@@ -621,10 +631,12 @@ impl EiEventConverter {
         Ok(())
     }
 
+    /// Returns the next queued request if one exists.
     pub fn next_event(&mut self) -> Option<EiEvent> {
         self.events.pop_front()
     }
 
+    /// Adds a function to execute when the server informs that the the associated request is done.
     pub fn add_callback_handler<F: FnOnce(u64) + 'static>(
         &mut self,
         callback: ei::Callback,
@@ -667,11 +679,17 @@ pub struct Keymap {
 #[repr(u64)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub enum DeviceCapability {
+    /// Capability for relative pointer motion.
     Pointer = 1 << 0,
+    /// Capability for absolute pointer motion.
     PointerAbsolute = 1 << 1,
+    /// Capability for keyboard input events.
     Keyboard = 1 << 2,
+    /// Capability for touch input events.
     Touch = 1 << 3,
+    /// Capability for scroll input events.
     Scroll = 1 << 4,
+    /// Capability for mouse button input events.
     Button = 1 << 5,
 }
 
@@ -888,6 +906,7 @@ impl std::hash::Hash for Device {
 
 /// Enum containing all possible events the high-level utilities will give for a client implementation to handle.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(missing_docs)] // Inner types have docs
 pub enum EiEvent {
     // Connected,
     Disconnected(Disconnected),
@@ -952,14 +971,18 @@ impl EiEvent {
 /// High-level translation of [`ei_connection.disconnected`](ei::connection::Event::Disconnected).
 #[derive(Clone, Debug, PartialEq)]
 pub struct Disconnected {
+    /// Last serial sent by the EIS implementation.
     pub last_serial: u32,
+    /// Reason for disconnection.
     pub reason: ei::connection::DisconnectReason,
+    /// Explanation for debugging purposes.
     pub explanation: String,
 }
 
 /// High-level translation of the seat description events ending with [`ei_seat.done`](ei::seat::Event::Done).
 #[derive(Clone, Debug, PartialEq)]
 pub struct SeatAdded {
+    /// High-level [`Seat`] wrapper for the seat that was added.
     pub seat: Seat,
 }
 
@@ -969,6 +992,7 @@ pub struct SeatAdded {
 /// in an event.
 #[derive(Clone, Debug, PartialEq)]
 pub struct SeatRemoved {
+    /// High-level [`Seat`] wrapper for the seat that was removed.
     pub seat: Seat,
 }
 
@@ -994,6 +1018,7 @@ pub struct DeviceRemoved {
 pub struct DevicePaused {
     /// High-level [`Device`] wrapper.
     pub device: Device,
+    /// The event's serial number.
     pub serial: u32,
 }
 
@@ -1002,6 +1027,7 @@ pub struct DevicePaused {
 pub struct DeviceResumed {
     /// High-level [`Device`] wrapper.
     pub device: Device,
+    /// The event's serial number.
     pub serial: u32,
 }
 
@@ -1010,10 +1036,15 @@ pub struct DeviceResumed {
 pub struct KeyboardModifiers {
     /// High-level [`Device`] wrapper.
     pub device: Device,
+    /// The event's serial number.
     pub serial: u32,
+    /// Mask of modifiers in the depressed state.
     pub depressed: u32,
+    /// Mask of modifiers in the latched state.
     pub latched: u32,
+    /// Mask of modifiers in the locked state.
     pub locked: u32,
+    /// The current group or layout index in the keymap.
     pub group: u32,
 }
 
@@ -1022,6 +1053,7 @@ pub struct KeyboardModifiers {
 pub struct Frame {
     /// High-level [`Device`] wrapper.
     pub device: Device,
+    /// The event's serial number.
     pub serial: u32,
     /// Timestamp in microseconds.
     pub time: u64,
@@ -1032,7 +1064,9 @@ pub struct Frame {
 pub struct DeviceStartEmulating {
     /// High-level [`Device`] wrapper.
     pub device: Device,
+    /// The event's serial number.
     pub serial: u32,
+    /// The event's sequence number.
     pub sequence: u32,
 }
 
@@ -1041,6 +1075,7 @@ pub struct DeviceStartEmulating {
 pub struct DeviceStopEmulating {
     /// High-level [`Device`] wrapper.
     pub device: Device,
+    /// The event's serial number.
     pub serial: u32,
 }
 
@@ -1051,7 +1086,9 @@ pub struct PointerMotion {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Relative motion on the X axis.
     pub dx: f32,
+    /// Relative motion on the Y axis.
     pub dy: f32,
 }
 
@@ -1062,7 +1099,9 @@ pub struct PointerMotionAbsolute {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Absolute position on the X axis.
     pub dx_absolute: f32,
+    /// Absolute position on the Y axis.
     pub dy_absolute: f32,
 }
 
@@ -1073,7 +1112,9 @@ pub struct Button {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Button code, as in Linux's `input-event-codes.h`.
     pub button: u32,
+    /// State of the button.
     pub state: ei::button::ButtonState,
 }
 
@@ -1084,7 +1125,9 @@ pub struct ScrollDelta {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Motion on the X axis.
     pub dx: f32,
+    /// Motion on the Y axis.
     pub dy: f32,
 }
 
@@ -1095,7 +1138,9 @@ pub struct ScrollStop {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Whether motion on the X axis stopped.
     pub x: bool,
+    /// Whether motion on the Y axis stopped.
     pub y: bool,
 }
 
@@ -1106,7 +1151,9 @@ pub struct ScrollCancel {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Whether motion on the X axis was canceled.
     pub x: bool,
+    /// Whether motion on the Y axis was canceled.
     pub y: bool,
 }
 
@@ -1117,7 +1164,9 @@ pub struct ScrollDiscrete {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Discrete motion on the X axis.
     pub discrete_dx: i32,
+    /// Discrete motion on the Y axis.
     pub discrete_dy: i32,
 }
 
@@ -1143,7 +1192,9 @@ pub struct TouchDown {
     pub time: u64,
     /// Unique touch ID, defined in this event.
     pub touch_id: u32,
+    /// Absolute position on the X axis.
     pub x: f32,
+    /// Absolute position on the Y axis.
     pub y: f32,
 }
 
@@ -1156,7 +1207,9 @@ pub struct TouchMotion {
     pub time: u64,
     /// Unique touch ID, defined in [`TouchDown`].
     pub touch_id: u32,
+    /// Absolute position on the X axis.
     pub x: f32,
+    /// Absolute position on the Y axis.
     pub y: f32,
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -694,7 +694,7 @@ pub enum DeviceCapability {
 }
 
 impl DeviceCapability {
-    /// Returns the name of the interface for the first matched capability.
+    /// Returns the name of the interface.
     ///
     /// `None` is returned if none of the flags match
     pub(crate) fn interface_name(self) -> &'static str {
@@ -730,7 +730,7 @@ impl DeviceCapability {
     }
 }
 
-/// Lookup table from a single capability of [`SeatCapabilities`] to a protocol capability.
+/// Lookup table from [`DeviceCapability`] to a protocol capability.
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 struct CapabilityMap([u64; BitFlags::<DeviceCapability>::ALL.bits_c().count_ones() as usize]);
 

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -1,4 +1,6 @@
-// Generic `EiHandshaker` can be used in async or sync code
+//! Module implementing the EI protocol handshake.
+//!
+//! The generic [`EiHandshaker`] can be used in async and sync code.
 
 use crate::{ei, eis, util, Error, PendingRequestResult};
 use std::{collections::HashMap, error, fmt, mem, sync::OnceLock};
@@ -27,19 +29,29 @@ fn interfaces() -> &'static HashMap<&'static str, u32> {
     })
 }
 
+/// Handshake response.
 #[derive(Clone, Debug)]
 pub struct HandshakeResp {
+    /// Global `ei_connection` singleton object.
     pub connection: ei::Connection,
+    /// Serial number of `ei_handshake.connection`.
     pub serial: u32,
+    /// Interfaces along with their versions negotiated in the handshake.
     pub negotiated_interfaces: HashMap<String, u32>,
 }
 
+/// Error during handshake.
 #[derive(Debug)]
 pub enum HandshakeError {
+    /// Invalid object ID.
     InvalidObject(u64),
+    /// Non-handshake event.
     NonHandshakeEvent,
+    /// Missing required interface.
     MissingInterface,
+    /// Duplicate event.
     DuplicateEvent,
+    /// No [`ContextType`](ei::handshake::ContextType) sent in handshake.
     NoContextType,
 }
 
@@ -57,6 +69,7 @@ impl fmt::Display for HandshakeError {
 
 impl error::Error for HandshakeError {}
 
+/// Implementation of the EI protocol handshake on the client side.
 pub struct EiHandshaker<'a> {
     name: &'a str,
     context_type: ei::handshake::ContextType,
@@ -64,6 +77,7 @@ pub struct EiHandshaker<'a> {
 }
 
 impl<'a> EiHandshaker<'a> {
+    /// Creates a client-side handshaker.
     #[must_use]
     pub fn new(name: &'a str, context_type: ei::handshake::ContextType) -> Self {
         Self {
@@ -148,14 +162,20 @@ pub fn ei_handshake_blocking(
     }
 }
 
+/// Handshake response.
 #[derive(Clone, Debug)]
 pub struct EisHandshakeResp {
+    /// Global `ei_connection` singleton object.
     pub connection: eis::Connection,
+    /// Name of client.
     pub name: Option<String>,
+    /// Context type of connection.
     pub context_type: eis::handshake::ContextType,
+    /// Interfaces along with their versions negotiated in the handshake.
     pub negotiated_interfaces: HashMap<String, u32>,
 }
 
+/// Implementation of the EI protocol handshake on the server side.
 #[derive(Debug)]
 pub struct EisHandshaker {
     name: Option<String>,
@@ -165,6 +185,7 @@ pub struct EisHandshaker {
 }
 
 impl EisHandshaker {
+    /// Creates a server-side handshaker.
     #[must_use]
     pub fn new(context: &eis::Context, initial_serial: u32) -> Self {
         let handshake = context.handshake();

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -64,6 +64,7 @@ pub struct EiHandshaker<'a> {
 }
 
 impl<'a> EiHandshaker<'a> {
+    #[must_use]
     pub fn new(name: &'a str, context_type: ei::handshake::ContextType) -> Self {
         Self {
             name,
@@ -84,7 +85,7 @@ impl<'a> EiHandshaker<'a> {
                 handshake.handshake_version(1);
                 handshake.name(self.name);
                 handshake.context_type(self.context_type);
-                for (interface, version) in interfaces().iter() {
+                for (interface, version) in interfaces() {
                     handshake.interface_version(interface, *version);
                 }
                 handshake.finish();
@@ -154,6 +155,7 @@ pub struct EisHandshaker {
 }
 
 impl EisHandshaker {
+    #[must_use]
     pub fn new(context: &eis::Context, initial_serial: u32) -> Self {
         let handshake = context.handshake();
         handshake.handshake_version(1);
@@ -193,11 +195,11 @@ impl EisHandshaker {
                 if let Some((interface, server_version)) = interfaces().get_key_value(name.as_str())
                 {
                     self.negotiated_interfaces
-                        .insert(interface.to_string(), version.min(*server_version));
+                        .insert((*interface).to_string(), version.min(*server_version));
                 }
             }
             eis::handshake::Request::Finish => {
-                for (interface, version) in self.negotiated_interfaces.iter() {
+                for (interface, version) in &self.negotiated_interfaces {
                     handshake.interface_version(interface, *version);
                 }
 

--- a/src/handshake.rs
+++ b/src/handshake.rs
@@ -73,6 +73,11 @@ impl<'a> EiHandshaker<'a> {
         }
     }
 
+    /// Handles the given event, possibly returning a filled handshake response.
+    ///
+    /// # Errors
+    ///
+    /// The errors returned are protocol violations.
     pub fn handle_event(
         &mut self,
         event: ei::Event,
@@ -120,6 +125,11 @@ pub(crate) fn request_result<T>(result: PendingRequestResult<T>) -> Result<T, Er
     }
 }
 
+/// Executes the handshake in blocking mode.
+///
+/// # Errors
+///
+/// Will return `Err` if there is an I/O error or a protocol violation.
 pub fn ei_handshake_blocking(
     context: &ei::Context,
     name: &str,
@@ -170,6 +180,11 @@ impl EisHandshaker {
         }
     }
 
+    /// Handles the given request, possibly returning a filled handshake response.
+    ///
+    /// # Errors
+    ///
+    /// The errors returned are protocol violations.
     pub fn handle_request(
         &mut self,
         request: eis::Request,
@@ -195,7 +210,7 @@ impl EisHandshaker {
                 if let Some((interface, server_version)) = interfaces().get_key_value(name.as_str())
                 {
                     self.negotiated_interfaces
-                        .insert((*interface).to_string(), version.min(*server_version));
+                        .insert((*interface).to_owned(), version.min(*server_version));
                 }
             }
             eis::handshake::Request::Finish => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ mod private {
 // XXX
 // Want to fallback to higher number if exists, on server?
 // create on server, not client.
+#[must_use]
 pub fn default_socket_path() -> Option<PathBuf> {
     let mut path = PathBuf::from(env::var_os("XDG_RUNTIME_DIR")?);
     path.push("eis-0");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,19 @@
+//! Reis 🍚 provides a Rust version of EI 🥚 and EIS 🍨 for emulated input on Wayland.
+//!
+//! See the upstream project [libei](https://gitlab.freedesktop.org/libinput/libei) for more information.
+//!
+//! This library is currently **incomplete** and subject to change. It should probably do more to provide a more high level API that handles the things a client/server needs to deal with.
+//!
+//! Setting the env var `REIS_DEBUG` will make the library print ei messages it sends and receives.
+//!
+//! # Features
+//!
+//! `reis` has the following Cargo features:
+//!
+//! - `tokio`: Enables tokio support for clients.
+//! - `calloop`: Enables calloop sources for EIS implementations. Somewhat experimental and
+//!   incomplete.
+
 #![forbid(unsafe_code)]
 
 // TODO split up
@@ -38,6 +54,7 @@ mod private {
 // XXX
 // Want to fallback to higher number if exists, on server?
 // create on server, not client.
+/// Returns the default socket path for EIS.
 #[must_use]
 pub fn default_socket_path() -> Option<PathBuf> {
     let mut path = PathBuf::from(env::var_os("XDG_RUNTIME_DIR")?);

--- a/src/object.rs
+++ b/src/object.rs
@@ -30,7 +30,7 @@ impl Eq for Object {}
 
 impl hash::Hash for Object {
     fn hash<H: hash::Hasher>(&self, hasher: &mut H) {
-        self.0.id.hash(hasher)
+        self.0.id.hash(hasher);
     }
 }
 
@@ -52,8 +52,8 @@ impl Object {
     ) -> Self {
         Self(Arc::new(ObjectInner {
             backend,
-            id,
             client_side,
+            id,
             interface,
             version,
         }))
@@ -62,6 +62,7 @@ impl Object {
     /// Returns a handle to the backend.
     ///
     /// Returns `None` if the backend has been destroyed.
+    #[must_use]
     pub fn backend(&self) -> Option<Backend> {
         self.0.backend.upgrade()
     }
@@ -74,6 +75,7 @@ impl Object {
 
     /// Returns `true` if the backend has this object, and `false` otherwise or if the backend
     /// has been destroyed.
+    #[must_use]
     pub fn is_alive(&self) -> bool {
         if let Some(backend) = self.backend() {
             backend.has_object_for_id(self.id())
@@ -84,6 +86,7 @@ impl Object {
 
     /// Returns the object's
     /// [ID](https://libinput.pages.freedesktop.org/libei/doc/types/index.html#object-ids).
+    #[must_use]
     pub fn id(&self) -> u64 {
         self.0.id
     }
@@ -92,11 +95,13 @@ impl Object {
     ///
     /// Interface names for new objects aren't usually transmitted, but rather come from
     /// the protocol definition.
+    #[must_use]
     pub fn interface(&self) -> &str {
         &self.0.interface
     }
 
     /// Returns the version of the interface of this object.
+    #[must_use]
     pub fn version(&self) -> u32 {
         self.0.version
     }
@@ -139,6 +144,7 @@ impl Object {
     /// keyboard.key(0x41, KeyState::Press);
     /// ```
     // TODO(axka, 2025-07-02): return Result<T, Self>
+    #[must_use]
     pub fn downcast<T: Interface>(self) -> Option<T> {
         if (self.0.client_side, self.interface()) == (T::CLIENT_SIDE, T::NAME) {
             Some(self.downcast_unchecked())

--- a/src/request.rs
+++ b/src/request.rs
@@ -27,7 +27,7 @@ pub enum RequestError {
 impl fmt::Display for RequestError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::InvalidCapabilities => write!(f, "invalid capabilities"),
+            Self::InvalidCapabilities => write!(f, "Invalid capabilities"),
         }
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -18,8 +18,10 @@ use std::{
 
 pub use crate::event::DeviceCapability;
 
+/// Protocol errors of the client.
 #[derive(Debug)]
 pub enum RequestError {
+    /// Invalid capabilities in `ei_seat.bind`.
     InvalidCapabilities,
 }
 impl fmt::Display for RequestError {
@@ -240,6 +242,7 @@ impl EisRequestConverter {
         }
     }
 
+    /// Returns a handle to the connection used by this converer.
     #[must_use]
     pub fn handle(&self) -> &Connection {
         &self.connection
@@ -276,6 +279,7 @@ impl EisRequestConverter {
         }
     }
 
+    /// Returns the next queued request if one exists.
     pub fn next_request(&mut self) -> Option<EisRequest> {
         self.requests.pop_front()
     }
@@ -737,6 +741,7 @@ impl std::hash::Hash for Seat {
     }
 }
 
+/// Trait marking interfaces that can be on devices.
 pub trait DeviceInterface: eis::Interface {}
 
 macro_rules! impl_device_interface {
@@ -920,6 +925,7 @@ impl std::hash::Hash for Device {
 
 /// Enum containing all possible requests the high-level utilities will give for a server implementation to handle.
 #[derive(Clone, Debug, PartialEq)]
+#[allow(missing_docs)] // Inner types have docs
 pub enum EisRequest {
     // TODO connect, disconnect, device closed
     Disconnect,
@@ -997,6 +1003,7 @@ impl EisRequest {
 pub struct Bind {
     /// High-level [`Seat`] wrapper.
     pub seat: Seat,
+    /// Capabilities requested by the client.
     pub capabilities: BitFlags<DeviceCapability>,
 }
 
@@ -1005,6 +1012,7 @@ pub struct Bind {
 pub struct Frame {
     /// High-level [`Device`] wrapper.
     pub device: Device,
+    /// Last serial sent by the EIS implementation.
     pub last_serial: u32,
     /// Timestamp in microseconds.
     pub time: u64,
@@ -1015,7 +1023,9 @@ pub struct Frame {
 pub struct DeviceStartEmulating {
     /// High-level [`Device`] wrapper.
     pub device: Device,
+    /// Last serial sent by the EIS implementation.
     pub last_serial: u32,
+    /// The event's sequence number.
     pub sequence: u32,
 }
 
@@ -1024,6 +1034,7 @@ pub struct DeviceStartEmulating {
 pub struct DeviceStopEmulating {
     /// High-level [`Device`] wrapper.
     pub device: Device,
+    /// Last serial sent by the EIS implementation.
     pub last_serial: u32,
 }
 
@@ -1034,7 +1045,9 @@ pub struct PointerMotion {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Relative motion on the X axis.
     pub dx: f32,
+    /// Relative motion on the Y axis.
     pub dy: f32,
 }
 
@@ -1045,7 +1058,9 @@ pub struct PointerMotionAbsolute {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Absolute position on the X axis.
     pub dx_absolute: f32,
+    /// Absolute position on the Y axis.
     pub dy_absolute: f32,
 }
 
@@ -1056,7 +1071,9 @@ pub struct Button {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Button code, as in Linux's `input-event-codes.h`.
     pub button: u32,
+    /// State of the button.
     pub state: eis::button::ButtonState,
 }
 
@@ -1067,7 +1084,9 @@ pub struct ScrollDelta {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Motion on the X axis.
     pub dx: f32,
+    /// Motion on the Y axis.
     pub dy: f32,
 }
 
@@ -1078,7 +1097,9 @@ pub struct ScrollStop {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Whether motion on the X axis stopped.
     pub x: bool,
+    /// Whether motion on the Y axis stopped.
     pub y: bool,
 }
 
@@ -1089,7 +1110,9 @@ pub struct ScrollCancel {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Whether motion on the X axis was canceled.
     pub x: bool,
+    /// Whether motion on the Y axis was canceled.
     pub y: bool,
 }
 
@@ -1100,7 +1123,9 @@ pub struct ScrollDiscrete {
     pub device: Device,
     /// Timestamp in microseconds.
     pub time: u64,
+    /// Discrete motion on the X axis.
     pub discrete_dx: i32,
+    /// Discrete motion on the Y axis.
     pub discrete_dy: i32,
 }
 
@@ -1126,7 +1151,9 @@ pub struct TouchDown {
     pub time: u64,
     /// Unique touch ID, defined in this request.
     pub touch_id: u32,
+    /// Absolute position on the X axis.
     pub x: f32,
+    /// Absolute position on the Y axis.
     pub y: f32,
 }
 
@@ -1139,7 +1166,9 @@ pub struct TouchMotion {
     pub time: u64,
     /// Unique touch ID, defined in [`TouchDown`].
     pub touch_id: u32,
+    /// Absolute position on the X axis.
     pub x: f32,
+    /// Absolute position on the Y axis.
     pub y: f32,
 }
 

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,3 +1,5 @@
+//! Module containing [`tokio`] event streams.
+
 // TODO: Handle writable fd too?
 
 use futures::stream::{Stream, StreamExt};
@@ -12,6 +14,7 @@ pub use crate::handshake::{HandshakeError, HandshakeResp};
 use crate::{ei, handshake::EiHandshaker, Error, PendingRequestResult};
 
 // XXX make this ei::EventStream?
+/// Stream of `ei::Event`s.
 pub struct EiEventStream(AsyncFd<ei::Context>);
 
 impl EiEventStream {
@@ -65,6 +68,7 @@ impl Stream for EiEventStream {
 }
 
 // TODO rename EiProtoEventStream
+/// EI convert event stream.
 pub struct EiConvertEventStream {
     inner: EiEventStream,
     converter: crate::event::EiEventConverter,

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -15,6 +15,11 @@ use crate::{ei, handshake::EiHandshaker, Error, PendingRequestResult};
 pub struct EiEventStream(AsyncFd<ei::Context>);
 
 impl EiEventStream {
+    /// Creates a new event stream.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if the underlying async file descriptor registration fails.
     pub fn new(context: ei::Context) -> io::Result<Self> {
         AsyncFd::with_interest(context, tokio::io::Interest::READABLE).map(Self)
     }
@@ -113,6 +118,11 @@ impl Stream for EiConvertEventStream {
     }
 }
 
+/// Executes the handshake in async mode.
+///
+/// # Errors
+///
+/// Will return `Err` if there is an I/O error or a protocol violation.
 pub async fn ei_handshake(
     events: &mut EiEventStream,
     name: &str,
@@ -133,6 +143,11 @@ pub async fn ei_handshake(
 }
 
 impl ei::Context {
+    /// Executes the handshake in async mode.
+    ///
+    /// # Errors
+    ///
+    /// Will return `Err` if there is an I/O error or a protocol violation.
     pub async fn handshake_tokio(
         &self,
         name: &str,

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,7 +19,7 @@ pub fn array_from_iterator_unchecked<T: Copy + Default, I: Iterator<Item = T>, c
     mut iter: I,
 ) -> [T; N] {
     let mut arr = [T::default(); N];
-    for i in arr.iter_mut() {
+    for i in &mut arr {
         *i = iter.next().unwrap();
     }
     arr

--- a/src/wire/arg.rs
+++ b/src/wire/arg.rs
@@ -49,7 +49,9 @@ impl Arg<'_> {
         match self {
             Arg::Uint32(value) => buf.extend(value.to_ne_bytes()),
             Arg::Int32(value) => buf.extend(value.to_ne_bytes()),
-            Arg::Uint64(value) => buf.extend(value.to_ne_bytes()),
+            Arg::Uint64(value) | Arg::NewId(value) | Arg::Id(value) => {
+                buf.extend(value.to_ne_bytes());
+            }
             Arg::Int64(value) => buf.extend(value.to_ne_bytes()),
             Arg::Float(value) => buf.extend(value.to_ne_bytes()),
             // XXX unwrap?
@@ -67,8 +69,6 @@ impl Arg<'_> {
                     buf.extend((0..4 - (len % 4)).map(|_| b'\0'));
                 }
             }
-            Arg::NewId(value) => buf.extend(value.to_ne_bytes()),
-            Arg::Id(value) => buf.extend(value.to_ne_bytes()),
         }
     }
 }

--- a/src/wire/backend.rs
+++ b/src/wire/backend.rs
@@ -93,10 +93,14 @@ impl AsFd for Backend {
     }
 }
 
+/// Pending message result.
 #[derive(Debug)]
 pub enum PendingRequestResult<T> {
+    /// The message. Either an event or a request.
     Request(T),
+    /// Wire format parse error.
     ParseError(ParseError),
+    /// Invalid object ID.
     InvalidObject(u64),
 }
 

--- a/src/wire/backend.rs
+++ b/src/wire/backend.rs
@@ -161,7 +161,7 @@ impl Backend {
                     return Ok(total_count);
                 }
                 Err(err) => return Err(err.into()),
-            };
+            }
         }
     }
 
@@ -271,10 +271,10 @@ impl Backend {
     fn print_msg(&self, object_id: u64, opcode: u32, args: &[Arg], incoming: bool) {
         let object = self.object_for_id(object_id);
         let interface = object.as_ref().map_or("UNKNOWN", |x| x.interface());
-        let op_name = if self.0.client != incoming {
-            eis::Request::op_name(interface, opcode)
-        } else {
+        let op_name = if self.0.client == incoming {
             ei::Event::op_name(interface, opcode)
+        } else {
+            eis::Request::op_name(interface, opcode)
         }
         .unwrap_or("UNKNOWN");
         if incoming {

--- a/src/wire/mod.rs
+++ b/src/wire/mod.rs
@@ -101,16 +101,26 @@ impl<'a> ByteStream<'a> {
     }
 }
 
+/// Wire format parse error.
 #[derive(Debug)]
 pub enum ParseError {
+    /// End of message while parsing argument.
     EndOfMessage,
+    /// Invalid UTF-8 string in message.
     Utf8(FromUtf8Error),
+    /// Invalid object ID.
     InvalidId(u64),
+    /// Expected file descriptor.
     NoFd,
+    /// Invalid opcode for interface.
     InvalidOpcode(&'static str, u32),
+    /// Invalid variant for enum.
     InvalidVariant(&'static str, u32),
+    /// Unknown interface.
     InvalidInterface(String),
+    /// Message header is too short.
     HeaderLength(u32),
+    /// Message length didn't match header.
     MessageLength(u32, u32),
 }
 
@@ -122,10 +132,10 @@ impl fmt::Display for ParseError {
             Self::InvalidId(id) => write!(f, "new object id '{id}' invalid"),
             Self::NoFd => write!(f, "expected fd"),
             Self::InvalidOpcode(intr, op) => {
-                write!(f, "opcode '{op}' invallid for interface '{intr}'")
+                write!(f, "opcode '{op}' invalid for interface '{intr}'")
             }
             Self::InvalidVariant(enum_, var) => {
-                write!(f, "variant '{var}' invallid for enum '{enum_}'")
+                write!(f, "variant '{var}' invalid for enum '{enum_}'")
             }
             Self::InvalidInterface(intr) => write!(f, "unknown interface '{intr}'"),
             Self::HeaderLength(len) => write!(f, "header length {len} < 16"),


### PR DESCRIPTION
This removes the need for slices and `Vec`s, and makes client and server code a lot simpler to implement with `BitFlags::contains` and friends.