### PR TITLE
fix: skip empty SCM_RIGHTS when no fds to send

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -33,11 +33,19 @@ pub fn send_with_fds(
     buf: &[IoSlice],
     fds: &[BorrowedFd],
 ) -> rustix::io::Result<usize> {
-    #[allow(clippy::manual_slice_size_calculation)]
-    let mut cmsg_space = vec![MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(fds.len()))];
-    let mut cmsg_buffer = net::SendAncillaryBuffer::new(&mut cmsg_space);
-    cmsg_buffer.push(net::SendAncillaryMessage::ScmRights(fds));
-    retry_on_intr(|| net::sendmsg(socket, buf, &mut cmsg_buffer, net::SendFlags::NOSIGNAL))
+    if fds.is_empty() {
+        // No fds to send — use sendmsg without ancillary data.
+        // Sending an empty SCM_RIGHTS message confuses some EIS servers (KWin).
+        let mut cmsg_buffer = net::SendAncillaryBuffer::new(&mut []);
+        retry_on_intr(|| net::sendmsg(socket, buf, &mut cmsg_buffer, net::SendFlags::NOSIGNAL))
+    } else {
+        #[allow(clippy::manual_slice_size_calculation)]
+        let mut cmsg_space =
+            vec![MaybeUninit::uninit(); rustix::cmsg_space!(ScmRights(fds.len()))];
+        let mut cmsg_buffer = net::SendAncillaryBuffer::new(&mut cmsg_space);
+        cmsg_buffer.push(net::SendAncillaryMessage::ScmRights(fds));
+        retry_on_intr(|| net::sendmsg(socket, buf, &mut cmsg_buffer, net::SendFlags::NOSIGNAL))
+    }
 }
 
 pub fn recv_with_fds(


### PR DESCRIPTION
## Summary

- Skip attaching SCM_RIGHTS ancillary data in `send_with_fds` when the `fds` slice is empty
- When no fds need to be sent, use `sendmsg` without ancillary data instead of sending an empty SCM_RIGHTS message

## Problem

When `fds` is empty, `send_with_fds` constructs an `ScmRights(&[])` ancillary message with zero fds. Some EIS servers — notably KWin's `org.kde.KWin.EIS.RemoteDesktop` — interpret this empty SCM_RIGHTS as malformed and silently stop processing the connection. This causes the client to never receive seat/device events after the handshake completes.

## Fix

Check `fds.is_empty()` before constructing the ancillary buffer. When empty, call `sendmsg` with an empty `SendAncillaryBuffer` (no ancillary data at all). When fds are present, behavior is unchanged.

Found while porting [ei-type](https://github.com/markc/voice) (a keyboard injector for KDE Plasma 6 Wayland) from C/libei to Rust/reis.