### PR TITLE
fix: drain buffered events before poll_readable in EiConvertEventIterator

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1337,14 +1337,6 @@ impl Iterator for EiConvertEventIterator {
             if let Some(event) = self.converter.next_event() {
                 return Some(Ok(event));
             }
-            if let Err(err) = util::poll_readable(&self.context) {
-                return Some(Err(err.into()));
-            }
-            match self.context.read() {
-                Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return None,
-                Err(err) => return Some(Err(err.into())),
-                Ok(_) => {}
-            }
             while let Some(result) = self.context.pending_event() {
                 let request = match result {
                     PendingRequestResult::Request(request) => request,
@@ -1360,6 +1352,14 @@ impl Iterator for EiConvertEventIterator {
                 if let Err(err) = self.converter.handle_event(request) {
                     return Some(Err(err.into()));
                 }
+            }
+            if let Err(err) = util::poll_readable(&self.context) {
+                return Some(Err(err.into()));
+            }
+            match self.context.read() {
+                Err(err) if err.kind() == io::ErrorKind::UnexpectedEof => return None,
+                Err(err) => return Some(Err(err.into())),
+                Ok(_) => {}
             }
         }
     }


### PR DESCRIPTION
Fixes #24

`handshake_blocking` can leave events (e.g. ping) in the ring buffer. `next()` was calling `poll_readable` before draining the buffer, causing a deadlock: we block on the socket while the compositor waits for `ping.done(0)`.

Fix: drain `context.pending_event()` before calling `poll_readable`.